### PR TITLE
Fix C# build errors

### DIFF
--- a/scenes/ChunkLoader.cs
+++ b/scenes/ChunkLoader.cs
@@ -3,25 +3,25 @@ using Godot;
 [GlobalClass]
 public partial class ChunkLoader : Resource
 {
-    private Thread thread = new Thread();
+    private Godot.Thread thread = new Godot.Thread();
     private bool isRunning = true;
-    private Semaphore sem = new Semaphore();
+    private Godot.Semaphore sem = new Godot.Semaphore();
 
     private Godot.Collections.Array<Vector2I> chunkPositionsToLoad = new();
-    private Mutex chunkPositionsToLoadMtx = new Mutex();
+    private Godot.Mutex chunkPositionsToLoadMtx = new Godot.Mutex();
 
     private Godot.Collections.Array<Chunk> loadedChunks = new();
-    private Mutex loadedChunksMtx = new Mutex();
+    private Godot.Mutex loadedChunksMtx = new Godot.Mutex();
 
     private Godot.Collections.Array<Vector2I> chunkPositionsToLoadLocal = new();
     private Godot.Collections.Array<Chunk> loadedChunksLocal = new();
 
-    public override void _Init()
+    public ChunkLoader()
     {
         thread.Start(Callable.From(() => Loop()));
     }
 
-    public override void _ExitTree()
+    ~ChunkLoader()
     {
         isRunning = false;
         sem.Post();

--- a/scripts/Player.cs
+++ b/scripts/Player.cs
@@ -7,14 +7,14 @@ public partial class Player : CharacterBody3D
 
     private float lookSensetivity = 0.002f;
 
-    [NodePath("Camera3D")]
     private Camera3D camera3D;
 
-    [NodePath("Camera3D/RayCast3D")]
     private RayCast3D rayCast3D;
 
     public override void _Ready()
     {
+        camera3D = GetNode<Camera3D>("Camera3D");
+        rayCast3D = GetNode<RayCast3D>("Camera3D/RayCast3D");
         Input.MouseMode = Input.MouseModeEnum.Captured;
     }
 


### PR DESCRIPTION
## Summary
- fix thread initialization for `ChunkLoader`
- resolve `NodePath` attribute errors in `Player`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cb1516608328a385f1b364e3bfa7