### PR TITLE
Fix compile errors in Chunk and ChunkLoader

### DIFF
--- a/scenes/ChunkLoader.cs
+++ b/scenes/ChunkLoader.cs
@@ -60,8 +60,9 @@ public partial class ChunkLoader : Resource
 
     public bool HasLoadedChunks()
     {
-        bool result = !loadedChunks.IsEmpty();
+        bool result;
         Monitor.Enter(loadedChunksMtx);
+        result = loadedChunks.Count > 0;
         Monitor.Exit(loadedChunksMtx);
         return result;
     }

--- a/scripts/Chunk.cs
+++ b/scripts/Chunk.cs
@@ -112,8 +112,20 @@ public partial class Chunk : StaticBody3D
         Vector3 sideB = a - c;
         Vector3 normal = sideA.Cross(sideB);
 
-        surfaceTool.AddTriangleFan(new Godot.Collections.Array<Vector3>{a,b,c}, new Godot.Collections.Array<Vector2>{uvA,uvB,uvC}, null, null, new Godot.Collections.Array<Vector3>{normal});
-        surfaceTool.AddTriangleFan(new Godot.Collections.Array<Vector3>{a,c,d}, new Godot.Collections.Array<Vector2>{uvA,uvC,uvD}, null, null, new Godot.Collections.Array<Vector3>{normal});
+        surfaceTool.AddTriangleFan(
+            new Vector3[] { a, b, c },
+            new Vector2[] { uvA, uvB, uvC },
+            null,
+            null,
+            new Vector3[] { normal }
+        );
+        surfaceTool.AddTriangleFan(
+            new Vector3[] { a, c, d },
+            new Vector2[] { uvA, uvC, uvD },
+            null,
+            null,
+            new Vector3[] { normal }
+        );
     }
 
     public bool IsBlock(Vector3I blockPosition)


### PR DESCRIPTION
## Summary
- ensure chunk loader checks list count instead of non-existent `IsEmpty`
- pass arrays to `SurfaceTool.AddTriangleFan` as required by Godot API

## Testing
- `dotnet build` *(fails: Could not resolve SDK 'Godot.NET.Sdk')*

------
https://chatgpt.com/codex/tasks/task_e_6849ceb62a1c8328b524c03f28f68cf6