### PR TITLE
Fix compile error for ChunkManager Export attribute

### DIFF
--- a/scripts/ChunkManager.cs
+++ b/scripts/ChunkManager.cs
@@ -5,7 +5,7 @@ public partial class ChunkManager : Node3D
     [Export]
     public int Radius = 2;
 
-    [Export(PropertyName = "player")]
+    [Export]
     public NodePath PlayerPath;
 
     private CharacterBody3D Player;


### PR DESCRIPTION
## Summary
- remove invalid `PropertyName` argument in `ChunkManager` Export attribute

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849d42fc754832898bfcda730ac6ee6