### PR TITLE
Fix NodePath check in ChunkManager

### DIFF
--- a/scripts/ChunkManager.cs
+++ b/scripts/ChunkManager.cs
@@ -16,7 +16,7 @@ public partial class ChunkManager : Node3D
 
     public override void _Ready()
     {
-        if (PlayerPath != null && PlayerPath != NodePath.Empty)
+        if (PlayerPath != null && !PlayerPath.IsEmpty())
         {
             Player = GetNode<CharacterBody3D>(PlayerPath);
         }


### PR DESCRIPTION
## Summary
- fix usage of NodePath.Empty

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d6e7f8a48328874c2a5867bc9191